### PR TITLE
Do not return null from application

### DIFF
--- a/plugins/org.eclipse.cbi.p2repo.sbom/src/org/eclipse/cbi/p2repo/sbom/SBOMApplication.java
+++ b/plugins/org.eclipse.cbi.p2repo.sbom/src/org/eclipse/cbi/p2repo/sbom/SBOMApplication.java
@@ -242,7 +242,7 @@ public class SBOMApplication implements IApplication {
 			}
 		}
 
-		return null;
+		return IApplication.EXIT_OK;
 	}
 
 	private void generateIndex(Path indexPath, URI renderer, List<SBOMGenerator.Result> sbomGeneratorResults)


### PR DESCRIPTION
Currently the application return `null` but the javadoc seem to advice that it should return a status as an integer value.

As errors are currently seem to be reported with print outs, this at a first step always return `EXIT_OK` to at least report normal termination.