### PR TITLE
Add support for specify canonical source repositories for P2 Artifacts

### DIFF
--- a/plugins/org.eclipse.cbi.p2repo.sbom/src/org/eclipse/cbi/p2repo/sbom/SBOMApplication.java
+++ b/plugins/org.eclipse.cbi.p2repo.sbom/src/org/eclipse/cbi/p2repo/sbom/SBOMApplication.java
@@ -56,6 +56,7 @@ import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Properties;
 import java.util.Set;
 import java.util.TreeMap;
@@ -70,7 +71,6 @@ import java.util.jar.JarInputStream;
 import java.util.regex.Pattern;
 import java.util.stream.Collector;
 import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
@@ -132,7 +132,9 @@ import org.eclipse.equinox.p2.query.QueryUtil;
 import org.eclipse.equinox.p2.repository.ICompositeRepository;
 import org.eclipse.equinox.p2.repository.IRepository;
 import org.eclipse.equinox.p2.repository.IRepositoryManager;
+import org.eclipse.equinox.p2.repository.IRepositoryReference;
 import org.eclipse.equinox.p2.repository.artifact.IArtifactDescriptor;
+import org.eclipse.equinox.p2.repository.artifact.IArtifactRepository;
 import org.eclipse.equinox.p2.repository.artifact.IArtifactRepositoryManager;
 import org.eclipse.equinox.p2.repository.artifact.spi.ArtifactDescriptor;
 import org.eclipse.equinox.p2.repository.metadata.IMetadataRepository;
@@ -395,6 +397,8 @@ public class SBOMApplication implements IApplication {
 
 		private final List<URI> artifactRepositoryURIs = new ArrayList<>();
 
+		private List<ArtifactSourceRepository> artifactSourceRepositories;
+
 		private final List<IInstallableUnit> inclusiveContextIUs = new ArrayList<>();
 
 		private final List<IInstallableUnit> exclusiveContextIUs = new ArrayList<>();
@@ -424,6 +428,8 @@ public class SBOMApplication implements IApplication {
 		private IMetadataRepositoryManager metadataRepositoryManager;
 
 		private IArtifactRepositoryManager artifactRepositoryManager;
+
+		private List<String> p2ArtifactSourceRepositories;
 
 		private SBOMGenerator(List<String> args) throws Exception {
 			contentHandler = new ContentHandler(getArgument("-cache", args, null));
@@ -463,6 +469,7 @@ public class SBOMApplication implements IApplication {
 			jsonOutput = getArgument("-json-output", args, null);
 			json = getArgument("-json", args);
 			xml = getArgument("-xml", args) || !json && xmlOutput == null && jsonOutput == null;
+			p2ArtifactSourceRepositories = getArguments("-p2sources", args, List.of());
 		}
 
 		private List<Path> getOutputs() {
@@ -640,7 +647,7 @@ public class SBOMApplication implements IApplication {
 					}
 				}
 			}
-
+			loadSourceRepositories();
 			// Gather details from the actual artifacts in parallel.
 			for (var entry : artifactIUs.entrySet()) {
 				var iu = entry.getValue();
@@ -702,6 +709,38 @@ public class SBOMApplication implements IApplication {
 			generateJson(bom);
 
 			return Status.OK_STATUS;
+		}
+
+		private void loadArtifactSource(URI location, URI referenced, Set<URI> loaded) {
+			if (loaded.add(location)) {
+				try {
+					var artifactManager = getArtifactRepositoryManager();
+					var contains = artifactManager.contains(location);
+					var repository = artifactManager.loadRepository(location, new NullProgressMonitor());
+					artifactSourceRepositories
+							.add(new ArtifactSourceRepository(referenced == null ? location : referenced, repository));
+					if (!contains) {
+						artifactManager.removeRepository(location);
+					}
+					var metadataManager = getMetadataRepositoryManager();
+					contains = metadataManager.contains(location);
+					var references = metadataManager.loadRepository(location, new NullProgressMonitor())
+							.getReferences();
+					for (IRepositoryReference reference : references) {
+						if (reference.isEnabled()) {
+							loadArtifactSource(reference.getLocation(), location, loaded);
+						}
+					}
+					if (!contains) {
+						metadataManager.removeRepository(location);
+					}
+				} catch (Exception e) {
+					if (referenced == null) {
+						System.err
+								.println("Can't load p2 source repository: " + location + " it will be ignored: " + e);
+					}
+				}
+			}
 		}
 
 		private void buildArtifactMappings() {
@@ -1008,12 +1047,34 @@ public class SBOMApplication implements IApplication {
 
 			var location = getRedirectedURI(
 					isMetadata(artifactDescriptor) ? URI.create(artifactDescriptor.getProperty("location"))
-							: artifactDescriptor.getRepository().getLocation());
+							: getArtifactLocation(artifactDescriptor));
 			var artifactKey = artifactDescriptor.getArtifactKey();
 			var encodedLocation = urlEncodeQueryParameter(location.toString());
 			var purl = "pkg:p2/" + artifactKey.getId() + "@" + artifactKey.getVersion() + "?classifier="
 					+ artifactKey.getClassifier() + "&location=" + encodedLocation;
 			component.setPurl(purl);
+		}
+
+		private URI getArtifactLocation(IArtifactDescriptor artifactDescriptor) {
+			// First see if there are any explicitly configured source repositories
+			if (!p2ArtifactSourceRepositories.isEmpty()) {
+				for (ArtifactSourceRepository repository : artifactSourceRepositories) {
+					if (repository.contains(artifactDescriptor)) {
+						return repository.uri();
+					}
+				}
+			}
+			// if not use where we have fetched this from
+			return artifactDescriptor.getRepository().getLocation();
+		}
+
+		private synchronized void loadSourceRepositories() {
+			if (artifactSourceRepositories == null && !p2ArtifactSourceRepositories.isEmpty()) {
+				artifactSourceRepositories = new ArrayList<>();
+				for (String srcRepoUri : p2ArtifactSourceRepositories) {
+					loadArtifactSource(URI.create(srcRepoUri), null, new HashSet<>());
+				}
+			}
 		}
 
 		private URI getRedirectedURI(URI location) {
@@ -2348,5 +2409,30 @@ public class SBOMApplication implements IApplication {
 
 			return uriRedirections;
 		}
+	}
+
+	private static final record ArtifactSourceRepository(URI uri, IArtifactRepository repository) {
+
+		public boolean contains(IArtifactDescriptor otherDescriptor) {
+			var descriptors = repository.getArtifactDescriptors(otherDescriptor.getArtifactKey());
+			if (descriptors.length > 0) {
+				var otherProperties = otherDescriptor.getProperties();
+				for (IArtifactDescriptor descriptor : descriptors) {
+					var thisProperties = descriptor.getProperties();
+					// we want at least one checksum to match!
+					if (thisProperties.keySet().stream().filter(key -> key.startsWith("download.checksum."))
+							.anyMatch(key -> Objects.equals(thisProperties.get(key), otherProperties.get(key)))) {
+						return true;
+					}
+					// not so good but better than nothing, if size is equal... e.g for local
+					// artifacts we only have size as P2 do not store more properties sadly
+					if (Objects.equals(thisProperties.get("download.size"), otherProperties.get("download.size"))) {
+						return true;
+					}
+				}
+			}
+			return false;
+		}
+
 	}
 }


### PR DESCRIPTION
As there is no canonical source for P2 like maven-central it is hard to get "right" location for an artifact. It could even be that an internal proxy is sued and then the actual (public) source is hidden.

This now adds a new option `-p2sources` where one can specify a list of artifact repositories that are considered as the canonical source for the product to be build, e.g. this could be a specific eclipse release the product was build against, but maybe many (e.g. orbit, m2e, or other third party providers) that are searched for an artifact in given order and if one is found this url is used.

Example would be `-p2sources https://download.eclipse.org/releases/2025-03 https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/2025-03` so it would prefer to map to the simrel repo first, then to the orbit and if nothing found use the default source

> [!NOTE] 
> The improvement was gently sponsored by [Katalon](https://katalon.com/).