### PR TITLE
Add Common Platform Enumeration (CPE) support to generator

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -481,6 +481,44 @@ There are **many** available sources of potential external reference information
 - The OSGi `MANIFEST.MF` `Bundle-DocURL`, `Bundle-SCM`, and `Eclipse-SourceReferences` headers.
 - Various elements, e.g., `connection`, in a POM.
 
+### CPE (Common Platform Enumeration)
+
+The generator provides [CPE](https://cyclonedx.org/docs/1.6/json/#components_items_cpe) (Common Platform Enumeration) identifiers
+for components derived from Maven artifacts.
+CPE is a standardized naming scheme for IT products and platforms,
+enabling better correlation with vulnerability databases such as the [National Vulnerability Database (NVD)](https://nvd.nist.gov/).
+
+CPE identifiers follow the [CPE 2.3 format](https://nvd.nist.gov/products/cpe):
+```
+cpe:2.3:a:vendor:product:version:*:*:*:*:*:*:*
+```
+
+For example, a component with Maven coordinates `org.apache.commons:commons-logging:1.2` would receive:
+```
+cpe:2.3:a:apache:commons_logging:1.2:*:*:*:*:*:*:*
+```
+
+The CPE identifier is constructed from the Maven coordinates:
+- **vendor**: Normalized from the Maven `groupId` (e.g., `org.apache.commons` becomes `apache`)
+- **product**: Normalized from the Maven `artifactId` (e.g., `commons-logging` becomes `commons_logging`)
+- **version**: The Maven version
+
+The generator applies common conventions for well-known vendors such as Apache, Google, Eclipse, and others.
+CPE identifiers are generated for both top-level components and nested JAR components when Maven coordinates are available.
+
+
+For example, a component with P2 id `org.eclipse.equinox.p2.core` and  version `2.13.100.v235464` would receive:
+```
+cpe:2.3:a:eclipse:equinox_p2_core:2.13.100:*:*:*:*:*:*:*
+```
+
+
+The CPE identifier is constructed from the P2 coordinates:
+- **vendor**: Second part of reverse domain notation of the artifact ID (e.g., `org.eclipse.equinox.p2.core` becomes `eclipse`)
+- **product**: Remaining part of reverse domain notation of the artifact ID (e.g., `org.eclipse.equinox.p2.core` becomes `equinox_p2_core`)
+- **version**: The Artifacts P2 version without the qualifier (e.g. `2.13.100.v235464` becomes `2.13.100`)
+
+
 ### Dependencies
 
 As mentioned previously,

--- a/tests/org.eclipse.cbi.p2repo.sbom.tests/src/org/eclipse/cbi/p2repo/sbom/tests/SBOMTest.java
+++ b/tests/org.eclipse.cbi.p2repo.sbom.tests/src/org/eclipse/cbi/p2repo/sbom/tests/SBOMTest.java
@@ -54,4 +54,48 @@ public class SBOMTest {
 		System.out.println(jsonString);
 	}
 
+	@Test
+	public void testCPESupport() throws Exception {
+		// Test that CPE field is supported in CycloneDX Component model
+		var component = new Component();
+		component.setGroup("org.apache.commons");
+		component.setName("commons-logging");
+		component.setType(Component.Type.LIBRARY);
+		component.setVersion("1.2");
+		
+		// Set a CPE identifier
+		String cpe = "cpe:2.3:a:apache:commons_logging:1.2:*:*:*:*:*:*:*";
+		component.setCpe(cpe);
+		
+		var bom = new Bom();
+		bom.addComponent(component);
+
+		// Verify CPE is included in JSON output
+		var jsonGenerator = BomGeneratorFactory.createJson(Version.VERSION_16, bom);
+		var jsonString = jsonGenerator.toJsonString();
+		System.out.println("CPE Test JSON Output:");
+		System.out.println(jsonString);
+		
+		// Basic verification that CPE is present
+		if (!jsonString.contains("\"cpe\"")) {
+			throw new AssertionError("CPE field not found in JSON output");
+		}
+		if (!jsonString.contains(cpe)) {
+			throw new AssertionError("CPE value not found in JSON output");
+		}
+
+		// Verify CPE is included in XML output
+		var xmlGenerator = SBOMApplication.BOMUtil.createBomXMLGenerator(Version.VERSION_16, bom);
+		var xmlString = xmlGenerator.toXmlString();
+		System.out.println("CPE Test XML Output:");
+		System.out.println(xmlString);
+		
+		if (!xmlString.contains("<cpe>")) {
+			throw new AssertionError("CPE element not found in XML output");
+		}
+		if (!xmlString.contains(cpe)) {
+			throw new AssertionError("CPE value not found in XML output");
+		}
+	}
+
 }


### PR DESCRIPTION
Common Platform Enumeration (CPE) is a structured naming scheme for information technology systems, software, and packages similar to PURLs

CPE data is critical for vulnerability management as it's used by:

- National Vulnerability Database (NVD)
- Common Vulnerabilities and Exposures (CVE) databases
- Security scanning tools

This is currently work-inprogress based on:
- https://github.com/laeubi/p2repo-sbom/pull/2

Current TODOs:

- [x] review and simplify the code, decide on best integration pattern and comply with current code structure
- [x] add new parameter `-cpe` to enable / disable the feature
- [x] remove unwanted content from the documentation
- [ ] ...

This PR is currently more to track progress and allows discussion of the general approach

> [!NOTE] 
> The improvement was gently sponsored by [Katalon](https://katalon.com/).